### PR TITLE
Fix undefined API_KEY usage

### DIFF
--- a/sd_revolution/civit_api.py
+++ b/sd_revolution/civit_api.py
@@ -11,10 +11,14 @@ import click
 import requests
 
 BASE_URL = "https://civitai.com/api/v1/"
-HEADERS = {
-    "Content-Type": "application/json",
-    "Authorization": f"Bearer {API_KEY}"
-}
+API_KEY = os.getenv("CIVIT_API_KEY")
+if API_KEY:
+    HEADERS = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {API_KEY}"
+    }
+else:
+    HEADERS = {"Content-Type": "application/json"}
 DOWNLOAD_DIR = 'data/models/'
 
 


### PR DESCRIPTION
## Summary
- avoid NameError in civit API helper by reading API key from environment

## Testing
- `python -m py_compile sd_revolution/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684367bebc74832c8cf281b58a7f3d75