### PR TITLE
Add tests for matrixify combinations

### DIFF
--- a/requirements-unlocked.txt
+++ b/requirements-unlocked.txt
@@ -1,2 +1,3 @@
 click
+pytest
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
 idna==3.7
+pytest==8.3.5
 requests==2.32.3
 urllib3==2.2.2

--- a/tests/test_matrixify.py
+++ b/tests/test_matrixify.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import pytest
+
+# Ensure the package can be imported when running tests directly via pytest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from sd_revolution.__main__ import generate_combinations
+
+def test_generate_combinations_two_lists():
+    sections = [["a", "b"], ["1", "2"]]
+    expected = [["a", "1"], ["a", "2"], ["b", "1"], ["b", "2"]]
+    assert generate_combinations(sections) == expected
+
+def test_generate_combinations_empty():
+    assert generate_combinations([]) == []


### PR DESCRIPTION
## Summary
- add `pytest` to dependencies
- test `generate_combinations` utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684369b70718832c9ba3c6d8bc3ee000